### PR TITLE
Remove logback.xml from classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,8 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
 
         <!-- FOR TESTS -->
@@ -140,6 +142,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/logback.xml</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Уберите плз конфиг logback из собранной библиотеки: https://mkyong.com/maven/maven-exclude-logback-xml-in-jar-file/

Это приводит к runtime error при использовании в spring boot:

`14:18:02,044 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
14:18:02,044 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
14:18:02,044 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [jar:file:/C:/Users/Sergey%20Chikin/.gradle/caches/modules-2/files-2.1/ru.moysklad.api/api-remap-1.2-sdk/2.3/d9754cce4570638659b9fb6a72cf817fb04b09a5/api-remap-1.2-sdk-2.3.jar!/logback.xml]
14:18:02,047 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@5e5d171f - URL [jar:file:/C:/Users/Sergey%20Chikin/.gradle/caches/modules-2/files-2.1/ru.moysklad.api/api-remap-1.2-sdk/2.3/d9754cce4570638659b9fb6a72cf817fb04b09a5/api-remap-1.2-sdk-2.3.jar!/logback.xml] is not of type file
14:18:02,082 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
14:18:02,088 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
14:18:02,093 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]
14:18:02,095 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
14:18:02,124 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@7:28 - no applicable action for [includeCallerData], current ElementPath  is [[Configuration][appender][includeCallerData]]
14:18:02,125 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to INFO
14:18:02,125 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to Logger[ROOT]
14:18:02,125 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
14:18:02,126 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@24313fcc - Registering current configuration as safe fallback point

14:18:02.361 [main] [SpringApplication.java:837] ERROR - Application run failed `

