### PR TITLE
MC-50459 заигнорил падающие в мастере тесты + минорные дополнения

### DIFF
--- a/src/main/java/ru/moysklad/remap_1_2/entities/discounts/BonusProgram.java
+++ b/src/main/java/ru/moysklad/remap_1_2/entities/discounts/BonusProgram.java
@@ -18,4 +18,5 @@ public class BonusProgram extends Discount implements Fetchable {
     private Integer spendRatePointsToRouble;
     private Integer maxPaidRatePercents;
     private Integer postponedBonusesDelayDays;
+    private Boolean earnWhileRedeeming;
 }

--- a/src/main/java/ru/moysklad/remap_1_2/utils/params/FilterParam.java
+++ b/src/main/java/ru/moysklad/remap_1_2/utils/params/FilterParam.java
@@ -148,10 +148,10 @@ public class FilterParam extends ApiParam {
 
     public enum FilterType {
         equals("="),
-        greater("~"),
-        lesser("~"),
-        greater_or_equals("~"),
-        lesser_or_equals("~"),
+        greater(">"),
+        lesser("<"),
+        greater_or_equals(">="),
+        lesser_or_equals("<="),
         not_equals("!="),
         equivalence("~"),
         equivalence_left("~="),

--- a/src/test/java/ru/moysklad/remap_1_2/entities/CurrencyTest.java
+++ b/src/test/java/ru/moysklad/remap_1_2/entities/CurrencyTest.java
@@ -1,5 +1,6 @@
 package ru.moysklad.remap_1_2.entities;
 
+import org.junit.Ignore;
 import ru.moysklad.remap_1_2.clients.EntityClientBase;
 import ru.moysklad.remap_1_2.responses.ListEntity;
 import ru.moysklad.remap_1_2.utils.ApiClientException;
@@ -46,6 +47,29 @@ public class CurrencyTest extends EntityGetUpdateDeleteTest {
         assertEquals(currency.getIsoCode(), retrievedEntity.getIsoCode());
         assertEquals(currency.getMajorUnit(), retrievedEntity.getMajorUnit());
         assertEquals(currency.getMinorUnit(), retrievedEntity.getMinorUnit());
+    }
+
+
+    //три теста ниже игнорятся до разнесения валюты на системную и несистемную
+    @Ignore
+    @Test
+    @Override
+    public void putTest() throws IOException, ApiClientException {
+        super.putTest();
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void massUpdateTest() throws IOException, ApiClientException {
+        super.massUpdateTest();
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void massCreateDeleteTest() throws IOException, ApiClientException {
+        super.massCreateDeleteTest();
     }
 
     @Override


### PR DESCRIPTION
Причина: после релиза тикета MC-49193 поле rateUpdateType (которое передается в запросе) стало невозможно ищменить после создания. На любую попытку передать это поле в запросе придет ошибка ._3007, "Нельзя менять автообновление курса у несистемной валюты".