### PR TITLE
Add downloadHref field to Meta

### DIFF
--- a/src/main/java/ru/moysklad/remap_1_2/entities/Meta.java
+++ b/src/main/java/ru/moysklad/remap_1_2/entities/Meta.java
@@ -52,6 +52,11 @@ public final class Meta {
     private String metadataHref;
 
     /**
+     * Ссылка на скачивание
+     */
+    private String downloadHref;
+
+    /**
      * Тип сущности
      */
     private Type type;


### PR DESCRIPTION
Добавлено отсутствующее свойство downloadHref в Meta:
https://dev.moysklad.ru/doc/api/remap/1.2/workbook/#workbook-metadannye
Свойство downloadHref особенно актуально при работе с изображениями.